### PR TITLE
Fixed createFiltersForm without query param "referrer"

### DIFF
--- a/src/Factory/FormFactory.php
+++ b/src/Factory/FormFactory.php
@@ -72,7 +72,7 @@ final class FormFactory
     {
         $filtersForm = $this->symfonyFormFactory->createNamed('filters', FiltersFormType::class, null, [
             'method' => 'GET',
-            'action' => $request->query->get('referrer'),
+            'action' => $request->query->get('referrer', ''),
             'ea_filters' => $filters,
         ]);
 


### PR DESCRIPTION
Fixed error: An error has occurred resolving the options of the form "EasyCorp\Bundle\EasyAdminBundle\Form\Type\FiltersFormType": The option "action" with value null is expected to be of type "string", but is of type "null".

